### PR TITLE
Add interactive RPC docs via OpenRPC

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ This repository contains the API definition and JavaScript implementations for c
 Unicity's infrastructure comprises a decentralized Agent layer interacting with a hierarchical Proof Aggregation layer. The communication API enables agents to:
 1. Submit state transition requests to the Aggregation layer.
 2. Retrieve unicity proofs that include timestamped inclusion proofs and global non-deletion proofs.
+For convenience the gateway serves interactive documentation powered by OpenRPC at `/docs`. The raw OpenRPC document can be fetched from `/openrpc` and the explorer allows sending test requests directly from the browser.
+
 
 ## API Operations
 

--- a/src/AggregatorGateway.ts
+++ b/src/AggregatorGateway.ts
@@ -28,6 +28,7 @@ import { ISmtStorage } from './smt/ISmtStorage.js';
 import { Smt } from './smt/Smt.js';
 import { SubmitCommitmentStatus } from './SubmitCommitmentResponse.js';
 import { MockAlphabillClient } from '../tests/consensus/alphabill/MockAlphabillClient.js';
+import { explorerHtml, openRpcDocument } from './docs/openRpcExplorer.js';
 
 export interface IGatewayConfig {
   aggregatorConfig?: IAggregatorConfig;
@@ -263,6 +264,15 @@ export class AggregatorGateway {
     let activeRequests = 0;
     app.use(cors());
     app.use(bodyParser.json());
+
+    app.get('/docs', (req: Request, res: Response) => {
+      res.setHeader('Content-Type', 'text/html');
+      res.send(explorerHtml());
+    });
+
+    app.get('/openrpc', (req: Request, res: Response) => {
+      res.json(openRpcDocument);
+    });
 
     app.get('/health', (req: Request, res: Response) => {
       res.status(200).json({

--- a/src/docs/openRpcExplorer.ts
+++ b/src/docs/openRpcExplorer.ts
@@ -1,0 +1,17 @@
+import openRpcDocument from './openrpc.json';
+
+export { openRpcDocument };
+
+export function explorerHtml(): string {
+  return `<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>AggregatorGateway RPC Explorer</title>
+    <script src="https://unpkg.com/@open-rpc/playground@latest" defer></script>
+  </head>
+  <body>
+    <open-rpc-playground rpc-doc-url="/openrpc"></open-rpc-playground>
+  </body>
+</html>`;
+}

--- a/src/docs/openRpcExplorer.ts
+++ b/src/docs/openRpcExplorer.ts
@@ -1,4 +1,4 @@
-import openRpcDocument from './openrpc.json';
+import openRpcDocument from './openrpc.json' with { type: 'json' };
 
 export { openRpcDocument };
 

--- a/src/docs/openrpc.json
+++ b/src/docs/openrpc.json
@@ -1,0 +1,59 @@
+{
+  "openrpc": "1.2.6",
+  "info": {
+    "title": "AggregatorGateway JSON-RPC API",
+    "version": "1.0.0",
+    "description": "JSON-RPC interface for interacting with the AggregatorGateway"
+  },
+  "servers": [
+    { "name": "HTTP", "url": "/" }
+  ],
+  "methods": [
+    {
+      "name": "submit_commitment",
+      "summary": "Submit a state transition commitment to the aggregator",
+      "params": [
+        {"name": "requestId", "required": true, "schema": {"type": "string"}},
+        {"name": "transactionHash", "required": true, "schema": {"type": "string"}},
+        {"name": "authenticator", "required": true, "schema": {"type": "object"}}
+      ],
+      "result": {"name": "result", "schema": {"type": "object"}}
+    },
+    {
+      "name": "get_inclusion_proof",
+      "summary": "Retrieve the inclusion proof for a submitted commitment",
+      "params": [
+        {"name": "requestId", "required": true, "schema": {"type": "string"}}
+      ],
+      "result": {"name": "result", "schema": {"type": "object"}}
+    },
+    {
+      "name": "get_no_deletion_proof",
+      "summary": "Retrieve the global no-deletion proof",
+      "params": [],
+      "result": {"name": "result", "schema": {"type": "object"}}
+    },
+    {
+      "name": "get_block_height",
+      "summary": "Get the current block height",
+      "params": [],
+      "result": {"name": "result", "schema": {"type": "object"}}
+    },
+    {
+      "name": "get_block",
+      "summary": "Get information about a specific block",
+      "params": [
+        {"name": "blockNumber", "required": true, "schema": {"type": "string"}}
+      ],
+      "result": {"name": "result", "schema": {"type": "object"}}
+    },
+    {
+      "name": "get_block_commitments",
+      "summary": "Get all commitments included in a specific block",
+      "params": [
+        {"name": "blockNumber", "required": true, "schema": {"type": "string"}}
+      ],
+      "result": {"name": "result", "schema": {"type": "array", "items": {"type": "object"}}}
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- document RPC interface using an OpenRPC spec
- serve `/docs` using OpenRPC playground
- expose the raw spec at `/openrpc`
- mention new OpenRPC docs in README

## Testing
- `npm test` *(fails: Could not find a working container runtime strategy)*