### PR TITLE
Add React OpenRPC UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,6 +87,9 @@ web_modules/
 .next
 out
 
+# Client build output
+public/openrpc/bundle.js
+
 # Nuxt.js build / generate output
 .nuxt
 dist

--- a/client/OpenRpcApp.tsx
+++ b/client/OpenRpcApp.tsx
@@ -1,0 +1,14 @@
+import React, { useEffect, useRef } from 'react';
+import Playground from '@open-rpc/playground';
+
+export default function OpenRpcApp(): JSX.Element {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (containerRef.current) {
+      Playground.init({ schemaUrl: '/openrpc.json' }, containerRef.current);
+    }
+  }, []);
+
+  return <div ref={containerRef} style={{ height: '100vh' }} />;
+}

--- a/client/index.tsx
+++ b/client/index.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import OpenRpcApp from './OpenRpcApp';
+
+document.addEventListener('DOMContentLoaded', () => {
+  const container = document.getElementById('root');
+  if (container) {
+    const root = createRoot(container);
+    root.render(<OpenRpcApp />);
+  }
+});

--- a/client/webpack.config.js
+++ b/client/webpack.config.js
@@ -1,0 +1,22 @@
+const path = require('path');
+
+module.exports = {
+  mode: 'production',
+  entry: path.resolve(__dirname, 'index.tsx'),
+  output: {
+    filename: 'bundle.js',
+    path: path.resolve(__dirname, '../public/openrpc'),
+  },
+  resolve: {
+    extensions: ['.tsx', '.ts', '.js'],
+  },
+  module: {
+    rules: [
+      {
+        test: /\.tsx?$/,
+        use: 'ts-loader',
+        exclude: /node_modules/,
+      },
+    ],
+  },
+};

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "This repository contains the API definition and JavaScript implementations for communication between the Agent and Aggregation layers on the Unicity blockchain platform.",
   "main": "./src/index.ts",
   "scripts": {
-    "build": "webpack",
+    "build": "webpack && npm run build:client",
+    "build:client": "webpack --config client/webpack.config.js",
     "start": "npm run build && node -r dotenv/config dist/index.cjs",
     "docker:mongo": "docker compose -f tests/docker/mongodb-docker-compose.yml up -d",
     "docker:mongo:down": "docker compose -f tests/docker/mongodb-docker-compose.yml down -v",
@@ -32,7 +33,10 @@
     "express": "5.1.0",
     "mongodb": "6.15.0",
     "mongoose": "8.13.2",
-    "winston": "3.17.0"
+    "winston": "3.17.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "@open-rpc/playground": "^1.11.5"
   },
   "devDependencies": {
     "@babel/preset-env": "7.26.9",
@@ -59,6 +63,8 @@
     "ts-loader": "9.5.2",
     "typescript-eslint": "8.30.1",
     "webpack": "5.99.6",
-    "webpack-cli": "6.0.1"
+    "webpack-cli": "6.0.1",
+    "@types/react": "^18.2.52",
+    "@types/react-dom": "^18.2.17"
   }
 }

--- a/public/openrpc/index.html
+++ b/public/openrpc/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <title>AggregatorGateway OpenRPC Playground</title>
+</head>
+<body style="margin:0">
+  <div id="root" style="height:100vh"></div>
+  <script src="bundle.js"></script>
+</body>
+</html>

--- a/src/AggregatorGateway.ts
+++ b/src/AggregatorGateway.ts
@@ -29,6 +29,8 @@ import { Smt } from './smt/Smt.js';
 import { SubmitCommitmentStatus } from './SubmitCommitmentResponse.js';
 import { MockAlphabillClient } from '../tests/consensus/alphabill/MockAlphabillClient.js';
 import { generateDocsHtml } from "./docs/jsonRpcDocs.js";
+import path from 'path';
+import { OPENRPC_DOCUMENT } from "./docs/openrpc.js";
 
 export interface IGatewayConfig {
   aggregatorConfig?: IAggregatorConfig;
@@ -268,6 +270,15 @@ export class AggregatorGateway {
     app.get("/docs", (req: Request, res: Response) => {
       res.setHeader("Content-Type", "text/html");
       res.send(generateDocsHtml());
+    });
+
+    app.use(
+      '/openrpc',
+      express.static(path.join(__dirname, '..', 'public', 'openrpc')),
+    );
+
+    app.get('/openrpc.json', (req: Request, res: Response) => {
+      res.json(OPENRPC_DOCUMENT);
     });
 
     app.get('/health', (req: Request, res: Response) => {

--- a/src/docs/openrpc.ts
+++ b/src/docs/openrpc.ts
@@ -1,0 +1,58 @@
+export const OPENRPC_DOCUMENT = {
+  openrpc: "1.2.6",
+  info: {
+    title: "AggregatorGateway API",
+    version: "1.0.0"
+  },
+  servers: [{ name: "RPC", url: "/" }],
+  methods: [
+    {
+      name: "submit_commitment",
+      summary: "Submit a state transition commitment to the aggregator.",
+      params: [
+        { name: "requestId", required: true, schema: { type: "string" } },
+        { name: "transactionHash", required: true, schema: { type: "string" } },
+        { name: "authenticator", required: true, schema: { type: "object" } }
+      ],
+      result: { name: "result", schema: { type: "object" } }
+    },
+    {
+      name: "get_inclusion_proof",
+      summary: "Retrieve the inclusion proof for a submitted commitment.",
+      params: [
+        { name: "requestId", required: true, schema: { type: "string" } }
+      ],
+      result: { name: "result", schema: { type: "object" } }
+    },
+    {
+      name: "get_no_deletion_proof",
+      summary: "Retrieve the global no-deletion proof.",
+      params: [],
+      result: { name: "result", schema: { type: "object" } }
+    },
+    {
+      name: "get_block_height",
+      summary: "Get the current block height.",
+      params: [],
+      result: { name: "result", schema: { type: "object" } }
+    },
+    {
+      name: "get_block",
+      summary: "Get information about a specific block.",
+      params: [
+        { name: "blockNumber", required: true, schema: { type: "string" } }
+      ],
+      result: { name: "result", schema: { type: "object" } }
+    },
+    {
+      name: "get_block_commitments",
+      summary: "Get all commitments included in a specific block.",
+      params: [
+        { name: "blockNumber", required: true, schema: { type: "string" } }
+      ],
+      result: { name: "result", schema: { type: "array", items: { type: "object" } } }
+    }
+  ]
+};
+
+// The React-based playground client consumes this document at /openrpc.json


### PR DESCRIPTION
## Summary
- bundle a React-based OpenRPC Playground client
- serve the bundled playground statically at `/openrpc`
- expose `/openrpc.json` with the OpenRPC document

## Testing
- `npm test` *(fails: Could not find a working container runtime)*
- `npm run test:no-docker`